### PR TITLE
Fix build issues #90

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# test data
+tests/pickled_transforms
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/release_pipeline.sh
+++ b/release_pipeline.sh
@@ -17,12 +17,12 @@ wheel_name="$(find ./dist -iname '*.whl')"
 version_number=$(cut -d- -f2 <<<"$wheel_name")
 
 # confirm release tar and version number
-printf "\nRelease tar will be: $release_file\n"
-printf "Release version/tag will be: $version_number\n\n"
+printf "\nRelease tar will be: %s\n" "$release_file"
+printf "Release version/tag will be: %s\n\n" "$version_number"
 
 # prompt if builds should be published
 echo -n "Confirm release (y/n)? "
-read answer
+read -r answer
 
 # release if requested
 if [[ "$answer" != "${answer#[Yy]}" ]] ;then

--- a/tests/pickled_transforms.py
+++ b/tests/pickled_transforms.py
@@ -44,6 +44,7 @@ def pickle_test_transforms(vidstab_obj, path):
         '{}/np_ostrich_smooth_trajectory_{}{}'
     ]
 
+    # noinspection PyProtectedMember
     paths = [p.format(path, vidstab_obj._smoothing_window, suffix) for p in base_paths]
 
     pickle_dump(vidstab_obj.transforms, paths[0])

--- a/tests/test_cv2_utils.py
+++ b/tests/test_cv2_utils.py
@@ -10,6 +10,7 @@ def missing_cv2(monkeypatch):
     """Monkey patch import to test missing cv2"""
     import_og = builtins.__import__
 
+    # noinspection PyShadowingBuiltins, PyUnusedLocal
     def mocked_import(name, globals, locals, fromlist, level):
         if name == 'cv2':
             raise ModuleNotFoundError()
@@ -32,6 +33,7 @@ def test_missing_cv2():
     assert 'pip install vidstab[cv2]' in str(err.value)
 
 
+# noinspection PyPep8Naming
 def test_cv2_estimateRigidTransform():
     missing_kps = np.empty((0,))
     transform = cv2_estimateRigidTransform(missing_kps, missing_kps)

--- a/tests/test_plot_utils.py
+++ b/tests/test_plot_utils.py
@@ -23,6 +23,7 @@ def check_vidstab_plot(plot, expected_axes1, expected_axes2):
     axes1_lims = int_axes_lims(axes1)
     axes2_lims = int_axes_lims(axes2)
 
+    # noinspection PyUnresolvedReferences
     fig_check = isinstance(fig, matplotlib.figure.Figure)
     axes1_check = axes1_lims == expected_axes1
     axes2_check = axes2_lims == expected_axes2

--- a/tests/test_vidstab_utils.py
+++ b/tests/test_vidstab_utils.py
@@ -67,6 +67,7 @@ def test_match_keypoints():
     prev_expected = cur_expected - 30
 
     assert (cur_matched_kps == cur_expected).all()
+    # noinspection PyUnresolvedReferences
     assert (prev_matched_kps == prev_expected).all()
 
 

--- a/vidstab/cv2_utils.py
+++ b/vidstab/cv2_utils.py
@@ -30,6 +30,7 @@ def cv2_estimateRigidTransform(from_pts, to_pts, full=False):
     if imutils.is_cv4():
         transform = cv2.estimateAffinePartial2D(from_pts, to_pts)[0]
     else:
+        # noinspection PyUnresolvedReferences
         transform = cv2.estimateRigidTransform(from_pts, to_pts, full)
 
     return transform

--- a/vidstab/download_videos.py
+++ b/vidstab/download_videos.py
@@ -20,7 +20,7 @@ def download_ostrich_video(download_to_path):
     >>> download_ostrich_video(path)
     >>>
     >>> stabilizer = VidStab()
-    >>> stabilizer.stabilize(path, OUTPUT_VIDEO_PATH)
+    >>> stabilizer.stabilize(path, 'output_path.avi')
     """
     urlretrieve(REMOTE_OSTRICH_VID_PATH, download_to_path)
 

--- a/vidstab/layer_utils.py
+++ b/vidstab/layer_utils.py
@@ -16,8 +16,8 @@ def layer_overlay(foreground, background):
     >>>
     >>> stabilizer = VidStab()
     >>>
-    >>> stabilizer.stabilize(input_path=INPUT_VIDEO_PATH,
-    >>>                      output_path=OUTPUT_VIDEO_PATH,
+    >>> stabilizer.stabilize(input_path='my_shaky_video.avi',
+    >>>                      output_path='stabilized_output.avi',
     >>>                      border_size=100,
     >>>                      layer_func=layer_overlay)
     """
@@ -43,8 +43,8 @@ def layer_blend(foreground, background, foreground_alpha=.6):
     >>>
     >>> stabilizer = VidStab()
     >>>
-    >>> stabilizer.stabilize(input_path=INPUT_VIDEO_PATH,
-    >>>                      output_path=OUTPUT_VIDEO_PATH,
+    >>> stabilizer.stabilize(input_path='my_shaky_video.avi',
+    >>>                      output_path='stabilized_output.avi',
     >>>                      border_size=100,
     >>>                      layer_func=layer_blend)
     """

--- a/visual_inspection_tests.py
+++ b/visual_inspection_tests.py
@@ -5,7 +5,6 @@ $ python -m cProfile -o temp.dat visual_inspection_tests.py
 $ snakeviz temp.dat
 """
 import tempfile
-import warnings
 from vidstab import VidStab, layer_overlay
 import vidstab.download_videos as dl
 


### PR DESCRIPTION
### In scope changes

* Lowered `atol` param of `np.allclose()` to satisfy tests.
    * An updated version of `np` is the top suspect of the issue.  If new updates cause tests to fall out of this `atol` then new transforms will need to be generated for test case and a note/updated min version about `np`.

### Out of scope changes

* Test data dir to gitignore (`tests/pickled_transforms` dir, where data is downloaded to perform test)
* Pleased ShellChecker/PyCharm inspector so all files have ✅
    * Sometimes this meant slight changes to code
    * Sometimes this meant addin `# nosinpection` comments for approved violations